### PR TITLE
docs: fix simple typo, ingore -> ignore

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -149,7 +149,7 @@ int Base64decode(char *bufplain, const char *bufcoded)
     nprbytes -= 4;
     }
 
-    /* Note: (nprbytes == 1) would be an error, so just ingore that case */
+    /* Note: (nprbytes == 1) would be an error, so just ignore that case */
     if (nprbytes > 1) {
     *(bufout++) =
         (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);


### PR DESCRIPTION
There is a small typo in base64.c.

Should read `ignore` rather than `ingore`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md