### PR TITLE
Switching base-image to official alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM n0madic/alpine-gcc:9.2.0
-RUN apk add --quiet --no-cache libressl-dev 
+FROM alpine:latest
+RUN apk add --quiet --no-cache gcc musl-dev make bash libressl-dev
 COPY ./*.h /opt/src/
 COPY ./*.c /opt/src/
 COPY Makefile /opt/src/
 COPY entrypoint.sh /
-#RUN apt-get install libssl-dev
 WORKDIR /opt/src
 RUN make
 RUN make OPENSSL=/usr/local/opt/openssl/include OPENSSL_LIB=-L/usr/local/opt/openssl/lib


### PR DESCRIPTION
This changes the base image to the official alpine one, thereby allowing multiplatform support (tested on Raspi4 arm64)