### PR TITLE
Some built-in stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS	= $(SRCS:.c=.o)
 all: $(NAME)
 
 $(NAME): $(OBJS)
-	$(CC) -o $(NAME) $(OBJS) $(LDFLAGS)
+	$(CC) -o $(NAME) $(OBJS) $(CFLAGS) $(LDFLAGS)
 
 clean:
 	rm -f $(OBJS)


### PR DESCRIPTION
Added wall-time measurement that measures ops/sec.  Basically, each thread keeps a count of its own attempts, then reports them before exiting via an atomic fetch and add.  Can be turned off with -D NO_STATS, but should be on by default, because the counter increment is negligable; it will not meaningfully impact performance.  Also, actually uses CFLAGS when building (the default build was NOT actually invoking -O3).