### PR TITLE
Fix security vulnerabilities and add Docker security hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+.github.workflows.trivy-analysis.yaml text eol=lf

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Run Trivy vulnerability scanner on the cloned repository files
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
-          version: 'v0.67.2'
+          version: 'v0.68.2'
           scan-type: 'fs'
           scanners: 'vuln,misconfig,secret,license'
           ignore-unfixed: true
@@ -43,7 +43,7 @@ jobs:
           ls -lash ${{ env.SARIF_FILE }}
           
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4.31.6
+        uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: ${{ env.SARIF_FILE }}
 

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -9,6 +9,8 @@ on:
   pull_request:
   workflow_dispatch:
   push:
+  schedule:
+    - cron: '0 0 1 */3 *'
 
 env:
   SARIF_FILE: 'trivy-results.sarif'
@@ -24,7 +26,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on the cloned repository files
         uses: aquasecurity/trivy-action@0.33.1
         with:
-          version: 'v0.67.0'
+          version: 'v0.67.2'
           scan-type: 'fs'
           scanners: 'vuln,misconfig,secret,license'
           ignore-unfixed: true
@@ -41,7 +43,7 @@ jobs:
           ls -lash ${{ env.SARIF_FILE }}
           
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.31.6
         with:
           sarif_file: ${{ env.SARIF_FILE }}
 

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -1,0 +1,49 @@
+name: Trivy Analysis
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+
+env:
+  SARIF_FILE: 'trivy-results.sarif'
+
+jobs:
+  build:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Run Trivy vulnerability scanner on the cloned repository files
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          version: 'v0.67.0'
+          scan-type: 'fs'
+          scanners: 'vuln,misconfig,secret,license'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: ${{ env.SARIF_FILE }}
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+
+      - name: Check Trivy scan results existence
+        run: |
+          if [ ! -f "${{ env.SARIF_FILE }}" ]; then
+            echo "Error: ${{ env.SARIF_FILE }} does not exist."
+            exit 1
+          fi
+          ls -lash ${{ env.SARIF_FILE }}
+          
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ env.SARIF_FILE }}
+
+
+

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -21,14 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Trivy vulnerability scanner on the cloned repository files
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          version: 'v0.68.2'
+          version: 'v0.73.0'
           scan-type: 'fs'
           scanners: 'vuln,misconfig,secret,license'
+          trivyignores: '.trivyignore.yaml'
           ignore-unfixed: true
           format: 'sarif'
           output: ${{ env.SARIF_FILE }}
@@ -41,11 +42,8 @@ jobs:
             exit 1
           fi
           ls -lash ${{ env.SARIF_FILE }}
-          
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: ${{ env.SARIF_FILE }}
-
-
-

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,11 @@
+# Trivy ignore rules. The scanner workflow
+# .github/workflows/trivy-analysis.yaml passes this file to the trivy-action
+# through its `trivyignores` input, so the rules below apply to the CI fs scan.
+misconfigurations:
+  # AVD-DS-0026: a Dockerfile should declare a HEALTHCHECK. Dockerfile.test
+  # builds the binary, runs the Valgrind security test once and exits, so a
+  # container healthcheck has nothing to poll. Scoped to that file, so the
+  # runtime Dockerfile, which does declare a HEALTHCHECK, is still checked.
+  - id: AVD-DS-0026
+    paths:
+      - "Dockerfile.test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.2 AS builder
+FROM alpine:latest AS builder
 
 RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev openssl-dev make
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,37 @@
-FROM frolvlad/alpine-gcc:latest
-# Update packages to get latest security fixes for OpenSSL (CVE-2025-9230, CVE-2025-9231, CVE-2025-9232)
-RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache libressl-dev make
+FROM alpine:latest AS builder
 
-# Create non-root user and group
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev openssl-dev make
 
 COPY ./*.h /opt/src/
 COPY ./*.c /opt/src/
 COPY Makefile /opt/src/
-COPY entrypoint.sh /
 
 WORKDIR /opt/src
-# Note: Only need one make command on Alpine Linux (macOS paths removed)
-RUN make
-RUN ["chmod", "+x", "/entrypoint.sh"]
-RUN ["chmod", "+x", "/opt/src/jwtcrack"]
+# Build with native CPU optimizations (Intel Xeon w5-2445 / Sapphire Rapids / x86-64-v4)
+RUN make CFLAGS="-I /usr/include/openssl -g -std=gnu99 -O3 -march=native -mtune=native"
 
-# Change ownership to non-root user
+FROM alpine:latest
+
+# CPU Requirements: x86-64-v4 (AVX-512 capable)
+# Optimized for: Intel Xeon w5-2445 (Sapphire Rapids)
+# Compatible with: Intel Xeon Scalable 4th Gen+, Intel Core 11th Gen+ with AVX-512
+LABEL org.opencontainers.image.title="c-jwt-cracker"
+LABEL org.opencontainers.image.description="Multi-threaded JWT brute-force cracker"
+LABEL org.opencontainers.image.source="https://github.com/maximmasiutin/c-jwt-cracker"
+LABEL org.opencontainers.image.authors="Maxim Masiutin"
+LABEL cpu.architecture="x86-64-v4"
+LABEL cpu.features="AVX-512"
+LABEL cpu.optimized-for="Intel Xeon w5-2445 (Sapphire Rapids)"
+
+RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache libssl3 libcrypto3
+
+# Create non-root user and group
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=builder /opt/src/jwtcrack /opt/src/jwtcrack
+COPY entrypoint.sh /
+
+RUN chmod +x /entrypoint.sh /opt/src/jwtcrack
 RUN chown -R appuser:appgroup /opt/src /entrypoint.sh
 
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS builder
+FROM alpine:3.21.2 AS builder
 
 RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev openssl-dev make
 
@@ -10,7 +10,7 @@ WORKDIR /opt/src
 # Build with native CPU optimizations (Intel Xeon w5-2445 / Sapphire Rapids / x86-64-v4)
 RUN make CFLAGS="-I /usr/include/openssl -g -std=gnu99 -O3 -march=native -mtune=native"
 
-FROM alpine:latest
+FROM alpine:3.21.2
 
 # CPU Requirements: x86-64-v4 (AVX-512 capable)
 # Optimized for: Intel Xeon w5-2445 (Sapphire Rapids)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS builder
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS builder
 
 RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev openssl-dev make
 
@@ -10,7 +10,7 @@ WORKDIR /opt/src
 # Build with native CPU optimizations (Intel Xeon w5-2445 / Sapphire Rapids / x86-64-v4)
 RUN make CFLAGS="-I /usr/include/openssl -g -std=gnu99 -O3 -march=native -mtune=native"
 
-FROM alpine:3.21.2
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 # CPU Requirements: x86-64-v4 (AVX-512 capable)
 # Optimized for: Intel Xeon w5-2445 (Sapphire Rapids)

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,6 @@
-FROM frolvlad/alpine-gcc:latest
-# Update packages to get latest security fixes for OpenSSL (CVE-2025-9230, CVE-2025-9231, CVE-2025-9232)
-RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache libressl-dev make valgrind bash coreutils
+FROM alpine:3.21.2
+# Update packages to get latest security fixes
+RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev libressl-dev make valgrind bash coreutils
 
 # Create non-root user for security (AVD-DS-0002)
 RUN addgroup -S testgroup && adduser -S testuser -G testgroup

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,22 @@
+FROM frolvlad/alpine-gcc:latest
+# Update packages to get latest security fixes for OpenSSL (CVE-2025-9230, CVE-2025-9231, CVE-2025-9232)
+RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache libressl-dev make valgrind bash coreutils
+
+# Create non-root user for security (AVD-DS-0002)
+RUN addgroup -S testgroup && adduser -S testuser -G testgroup
+
+COPY ./*.h /opt/src/
+COPY ./*.c /opt/src/
+COPY Makefile /opt/src/
+COPY test_security.sh /opt/src/
+
+WORKDIR /opt/src
+
+# Build with debug symbols for better Valgrind output
+RUN make CFLAGS="-g -O0"
+RUN chmod +x /opt/src/test_security.sh
+RUN chown -R testuser:testgroup /opt/src
+
+USER testuser
+
+CMD ["/opt/src/test_security.sh"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM alpine:3.21.2
+FROM alpine:latest
 # Update packages to get latest security fixes
 RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev libressl-dev make valgrind bash coreutils
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,8 @@
-FROM alpine:latest
+# This image builds the binary once, runs the Valgrind security test, and
+# exits. A one-shot test container has nothing for a HEALTHCHECK to poll, so
+# the missing-healthcheck advisory (AVD-DS-0026) is silenced for this file in
+# .trivyignore.yaml rather than answered with a meaningless probe.
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 # Update packages to get latest security fixes
 RUN apk update && apk upgrade --no-cache && apk add --quiet --no-cache gcc musl-dev libressl-dev make valgrind bash coreutils
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC	= gcc
 OPENSSL = /usr/include/openssl
 OPENSSL_LIB = -lssl
 
-CFLAGS	+= -I $(OPENSSL) -g -std=gnu99 -O3
+CFLAGS	+= -I $(OPENSSL) -g -std=gnu99 -O3 -march=native -mtune=native
 LDFLAGS	+= $(OPENSSL_LIB) -lcrypto -lpthread
 
 NAME	= jwtcrack

--- a/README.md
+++ b/README.md
@@ -1,94 +1,113 @@
-# JWT cracker
+# JWT Cracker
 
-A multi-threaded JWT brute-force cracker written in C. If you are very lucky or have a huge computing power, this program should find the secret key of a JWT token, allowing you to forge valid tokens. This is for testing purposes only, do not put yourself in trouble :)
+Multi-threaded JWT brute-force cracker in C. Tests all possible secret keys using HMAC verification against the token signature. For security testing only.
 
-I used the [Apple Base64 implementation](https://opensource.apple.com/source/QuickTimeStreamingServer/QuickTimeStreamingServer-452/CommonUtilitiesLib/base64.c) that I modified slightly.
+Uses modified [Apple Base64 implementation](https://opensource.apple.com/source/QuickTimeStreamingServer/QuickTimeStreamingServer-452/CommonUtilitiesLib/base64.c) with Base64URL support.
 
-## Build a Docker Image
+## Usage
+
+```
+./jwtcrack <token> [alphabet] [max_len] [hmac_alg]
+./jwtcrack --version
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| token | required | JWT to crack |
+| alphabet | `eariotnslcudpmhgbfywkvxzjqEARIOTNSLCUDPMHGBFYWKVXZJQ0123456789` | Characters to try |
+| max_len | 6 | Max secret length (1-1000) |
+| hmac_alg | sha256 | Hash function (see below) |
+
+### HMAC Algorithms
+
+- `sha256` - HS256 (HMAC-SHA256)
+- `sha384` - HS384 (HMAC-SHA384)
+- `sha512` - HS512 (HMAC-SHA512)
+
+Any OpenSSL-supported hash name works. Unknown names fall back to sha256.
+
+### Threading Model
+
+Creates N threads where N = alphabet length. Each thread handles secrets starting with one character.
+
+## Examples
+
+Basic (HS256):
+```
+./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE
+```
+
+Custom alphabet, max length 5, HS256:
+```
+./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234 5 sha256
+```
+Secret: `Sn1f` (< 1 second on modern CPU)
+
+HS512 example:
+```
+./jwtcrack eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJyb2xlIjoiYWRtaW4ifQ.RnWtv7Rjggm8LdMU3yLnz4ejgGAkIxoZwsCMuJlHMwTh7CJODDZWR8sVuNvo2ws25cbH9HWcp2n5WxpIZ9_v0g adimnps 9 sha512
+```
+Secret: `adminpass` (~15 seconds)
+
+HS384 example:
+```
+./jwtcrack eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiYWRtaW4ifQ.31xCH3k8VRqB8l5qBy7RyqI2htyCskBy_4cIWpk3o43UkIMW-IcjTUEL_NyFXUWJ 0123456789 6 sha384
+```
+
+## Build
+
+### Linux
+
+```
+apt-get install libssl-dev
+make
+```
+
+### macOS
+
+```
+brew install openssl
+make OPENSSL=/usr/local/opt/openssl/include OPENSSL_LIB=-L/usr/local/opt/openssl/lib
+```
+
+### Clean
+
+```
+make clean    # remove objects
+make fclean   # remove objects + binary
+make re       # full rebuild
+```
+
+## Docker
+
+Build:
 ```
 docker build . -t jwtcrack
-
 ```
 
-
-## Run on Docker
+Run:
 ```
-docker run -it --rm  jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE
+docker run -it --rm jwtcrack <token> [alphabet] [max_len] [hmac_alg]
 ```
 
-## Testing with Docker
-
-Build and run the test image which includes Valgrind for memory leak detection:
-
+Test (with Valgrind):
 ```
 docker build -f Dockerfile.test -t jwtcrack-test .
 docker run --rm jwtcrack-test
 ```
 
-This runs a functional test with 20 threads and a Valgrind memory check.
-
-## Manual Compilation
-
-Make sure you have openssl's headers installed.
-On Ubuntu you can install them with `apt-get install libssl-dev`
+## Benchmarking
 
 ```
-make
+/usr/bin/time -f "CPU seconds: %U\nWall time: %E" ./jwtcrack <token> <alphabet> <max_len> <hmac_alg>
 ```
 
-If you use a Mac, you can install OpenSSL with `brew install openssl`, but the headers will be stored in a
-different location:
+## Limitations
 
-```
-make OPENSSL=/usr/local/opt/openssl/include OPENSSL_LIB=-L/usr/local/opt/openssl/lib
-```
+- No progress indicator
+- Cannot resume interrupted runs
+- Performance depends on alphabet size and max_len
 
-## Run
+## Contributing
 
-```
-$ > ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE
-```                                                              
-
-## Run with different HMAC functions
-
-The following hash functions are supported for HMAC, i.e. to generate keyed-hashed message authentication codes: "sha256" for JSON HS256 (HMAC using SHA-256), "sha384" for HS384 and "sha512" for HS512, respectively. You can specify the name of any other hash function exactly as it is named in the OpenSSL. If OpenSSL allows this hash function to be used for HMAC, then jwtcrack will try to decode the secret. However, since jwtcrack is only a decoder, there is no guarantee that this algorithm was actually used for encoding, let alone among the list of algorithms allowed for the "JSON Web Algorithms" RFC. See section 3.1. of the RFC 7518 for more details.
-
-In the following example, we use a sha256 hash function that corresponds to JSON HS256 (HMAC-SHA256), see the "sha256" as a last command line parameter. Also, in this example we specify maximum secret length of 5 characters, and limit the alphabet to the following characters: ABCSNFabcsnf1234
-
-```
-$ > ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234 5 sha256
-```
-In the above example, the key is `Sn1f`, and it takes less than a second on an average notebook manufactured around 2019 (e.g. with an Intel CPU based on Ice Lake microarchitecture). GCC version 9.3.0 with "-O3" was used to compile the jwtcrack program. It was linked with the OpenSSL library version 1.1.1f under Linux Ubuntu 20.04.1 LTS.
-
-Here, in the next example, we use "sha512" as a last command line parameter to specify HS512 (HMAC-SHA512), we also specify maximum secret length of 9 characters, and limit the alphabet to the following seven lowercase latin characters: "adimnps".
-
-```
-$ > ./jwtcrack eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJyb2xlIjoiYWRtaW4ifQ.RnWtv7Rjggm8LdMU3yLnz4ejgGAkIxoZwsCMuJlHMwTh7CJODDZWR8sVuNvo2ws25cbH9HWcp2n5WxpIZ9_v0g adimnps 9 sha512
-```
-
-In the above example, the key is `adminpass`, and it takes about 15 seconds on average to decode on a notebook with Intel Core i7 1065G7 CPU on Ice Lake microarchitecture (2019), base frequency 1.30 GHz, max turbo 3.90 GHz). The combined number of CPU seconds consumed from each of the cores in the user mode due to multithreading is about 100 on average to decode that secret.
-
-
-Example of using "sha384":
-
-```
-$ > ./jwtcrack eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiYWRtaW4ifQ.31xCH3k8VRqB8l5qBy7RyqI2htyCskBy_4cIWpk3o43UkIMW-IcjTUEL_NyFXUWJ 0123456789 6 sha384
-```
-
-## Measurement of time consumed by jwtcrack
-
-```
-/usr/bin/time -f "Total number of CPU-seconds consumed directly from each of the CPU cores: %U\nElapsed real wall clock time used by the process: %E" ./jwtcrack eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJyb2xlIjoiYWRtaW4ifQ.RnWtv7Rjggm8LdMU3yLnz4ejgGAkIxoZwsCMuJlHMwTh7CJODDZWR8sVuNvo2ws25cbH9HWcp2n5WxpIZ9_v0g adimnps 9 sha512
-```
-
-## Contribute
-
- * No progress status
- * If you stop the program, you cannot start back where you were
- 
-## IMPORTANT: Known bugs
-
-The base64 implementation I use (from Apple) is sometimes buggy because not every Base64 implementation is the same.
-So sometimes, decrypting your Base64 token will only work partially and thus you will be able to find a secret to your token that is not the correct one.
-
-If someone is willing to implement a more robust Base64 implementation, that would be great :)
+See `FIXES-PROPOSED.md` for known issues and improvement proposals.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Multi-threaded JWT brute-force cracker in C. Tests all possible secret keys using HMAC verification against the token signature. For security testing only.
 
+## Purpose
+
+This tool is designed for **authorized security testing** to identify weak JWT secrets. Its explicit purpose is to recover and display the HMAC secret key used to sign a JWT token. Security scanners may flag the output of the discovered secret as "sensitive information logging" (CWE-200, CWE-312), but this is intentional and expected behavior - the entire point of the tool is to find and report weak secrets so they can be replaced with stronger ones.
+
+**Intended use cases:**
+- Penetration testing engagements (with authorization)
+- Security audits of JWT implementations
+- Verifying that production secrets are not weak or guessable
+- Educational purposes and CTF challenges
+
 Uses modified [Apple Base64 implementation](https://opensource.apple.com/source/QuickTimeStreamingServer/QuickTimeStreamingServer-452/CommonUtilitiesLib/base64.c) with Base64URL support.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ make re       # full rebuild
 
 ## Docker
 
+### Pre-built Image from DockerHub
+
+Pull the optimized image:
+```
+docker pull maximmasiutin/c-jwt-cracker:latest
+```
+
+**CPU Requirements:** x86-64-v4 architecture (AVX-512 capable). Compatible with:
+- Intel Xeon Scalable 4th Gen+ (Sapphire Rapids)
+- Intel Core 11th Gen+ with AVX-512 support
+- AMD EPYC 4th Gen (Genoa) with AVX-512
+
+Run:
+```
+docker run -it --rm maximmasiutin/c-jwt-cracker <token> [alphabet] [max_len] [hmac_alg]
+```
+
+### Build from Source
+
 Build:
 ```
 docker build . -t jwtcrack

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ docker build . -t jwtcrack
 docker run -it --rm  jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE
 ```
 
+## Testing with Docker
+
+Build and run the test image which includes Valgrind for memory leak detection:
+
+```
+docker build -f Dockerfile.test -t jwtcrack-test .
+docker run --rm jwtcrack-test
+```
+
+This runs a functional test with 20 threads and a Valgrind memory check.
+
 ## Manual Compilation
 
 Make sure you have openssl's headers installed.
@@ -78,6 +89,6 @@ $ > ./jwtcrack eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJyb2xlIjoiYWRtaW4ifQ.31xCH
 ## IMPORTANT: Known bugs
 
 The base64 implementation I use (from Apple) is sometimes buggy because not every Base64 implementation is the same.
-So sometimes, decrypting of your Base64 token will only work partially and thus you will be able to find a secret to your token that is not the correct one.
+So sometimes, decrypting your Base64 token will only work partially and thus you will be able to find a secret to your token that is not the correct one.
 
 If someone is willing to implement a more robust Base64 implementation, that would be great :)

--- a/base64.c
+++ b/base64.c
@@ -87,12 +87,14 @@
 #include "base64.h"
 
 /* aaaack but it's fast and const should make it shared text page. */
+/* Modified to support both Base64 (+/) and Base64URL (-_) per RFC 4648 */
 static const unsigned char pr2six[256] =
 {
     /* ASCII table */
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 63,
+ /* sp  !   "   #   $   %   &   '   (   )   *   +   ,   -   .   /  */
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 62, 64, 63,
     52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
     64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
     15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 63,
@@ -149,7 +151,7 @@ int Base64decode(char *bufplain, const char *bufcoded)
     nprbytes -= 4;
     }
 
-    /* Note: (nprbytes == 1) would be an error, so just ingore that case */
+    /* Note: (nprbytes == 1) would be an error, so just ignore that case */
     if (nprbytes > 1) {
     *(bufout++) =
         (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);

--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,44 @@
+/*
+
+Portability shims for platforms whose C runtime is missing a POSIX function
+this program relies on.
+
+The only case today is strndup. It is POSIX.1-2008 and is present on glibc and
+on macOS, but MinGW-w64's UCRT runtime does not provide it, so a native Windows
+build fails to link. Without a declaration the compiler also assumes an int
+return, which truncates the pointer on a 64-bit target long before the linker
+is reached.
+
+The fallback is compiled only where strndup is genuinely absent, so it changes
+nothing on the platforms that already have it.
+
+*/
+
+#ifndef JWTCRACK_COMPAT_H
+#define JWTCRACK_COMPAT_H
+
+#include <stddef.h>
+
+/* MinGW does not define strndup and does not set a feature macro that would let
+ * us detect it directly, so key off the toolchain. If a future MinGW gains
+ * strndup, defining HAVE_STRNDUP on the command line skips this shim. */
+#if defined(__MINGW32__) && !defined(HAVE_STRNDUP)
+
+#include <stdlib.h>
+#include <string.h>
+
+static inline char *strndup(const char *s, size_t n)
+{
+    size_t len = strnlen(s, n);
+    char *copy = (char *)malloc(len + 1);
+    if (copy == NULL) {
+        return NULL;
+    }
+    memcpy(copy, s, len);
+    copy[len] = '\0';
+    return copy;
+}
+
+#endif /* __MINGW32__ && !HAVE_STRNDUP */
+
+#endif /* JWTCRACK_COMPAT_H */

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-/opt/src/jwtcrack $@
+#!/bin/sh
+/opt/src/jwtcrack "$@"

--- a/main.c
+++ b/main.c
@@ -386,6 +386,13 @@ int main(int argc, char **argv) {
 	if (g_found_secret == NULL)
 		printf("No solution found :-(\n");
 	else
+		/*
+		 * SECURITY NOTE: Outputting the discovered secret is the explicit
+		 * purpose of this security testing tool. Static analyzers may flag
+		 * this as "sensitive information logging" (CWE-200, CWE-312), but
+		 * this is intentional - the tool exists to find weak JWT secrets
+		 * so they can be identified and replaced with stronger ones.
+		 */
 		printf("Secret is \"%s\"\n", g_found_secret);
 
 	for (size_t i = 0; i < g_alphabet_len; i++)

--- a/main.c
+++ b/main.c
@@ -17,6 +17,7 @@ see the "README.md" file for more details.
 #include <stdbool.h>
 #include <pthread.h>
 #include "base64.h"
+#include "compat.h"
 
 char *g_header_b64 = NULL; // Holds the Base64 header of the original JWT
 char *g_payload_b64 = NULL; // Holds the Base64 payload of the original JWT

--- a/test_security.sh
+++ b/test_security.sh
@@ -1,0 +1,664 @@
+#!/bin/bash
+# Security Test Suite for c-jwt-cracker
+# Tests Critical Security Issues documented in FIXES-PROPOSED.md
+
+# Note: We don't use 'set -e' because we intentionally test crash scenarios
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+echo "========================================"
+echo "SECURITY FIXES VERIFICATION SUITE"
+echo "========================================"
+echo ""
+echo "This test suite verifies that the security"
+echo "vulnerabilities have been properly fixed."
+echo ""
+
+#############################################
+# CRITICAL ISSUE 1: Race Condition (CWE-362)
+#############################################
+echo ""
+echo "########################################"
+echo "# CRITICAL 1: Race Condition (CWE-362)"
+echo "########################################"
+echo ""
+echo "The global variable g_found_secret is accessed"
+echo "by multiple threads without synchronization."
+echo "Location: main.c:78, 141, 153"
+echo ""
+
+# Test 1a: Helgrind race detection
+echo "--- Test 1a: Helgrind race detection ---"
+echo "Running Helgrind to detect data races..."
+echo ""
+valgrind --tool=helgrind --error-exitcode=42 \
+    ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234567 5 sha256 2>&1 | tee /tmp/helgrind.log
+HELGRIND_EXIT=${PIPESTATUS[0]}
+
+if [ $HELGRIND_EXIT -eq 42 ]; then
+    echo ""
+    echo ">>> VULNERABILITY CONFIRMED: Helgrind detected race conditions!"
+    echo ">>> See 'Possible data race' entries above."
+    RACE_DETECTED=1
+else
+    echo ""
+    echo "Helgrind did not detect races (exit code: $HELGRIND_EXIT)"
+    RACE_DETECTED=0
+fi
+
+# Test 1b: DRD race detection (more sensitive)
+echo ""
+echo "--- Test 1b: DRD race detection ---"
+echo "Running DRD (Data Race Detector)..."
+echo ""
+valgrind --tool=drd --error-exitcode=42 \
+    ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234567 5 sha256 2>&1 | tee /tmp/drd.log
+DRD_EXIT=${PIPESTATUS[0]}
+
+if [ $DRD_EXIT -eq 42 ]; then
+    echo ""
+    echo ">>> VULNERABILITY CONFIRMED: DRD detected race conditions!"
+    RACE_DETECTED=1
+else
+    echo ""
+    echo "DRD did not detect races (exit code: $DRD_EXIT)"
+fi
+
+if [ $RACE_DETECTED -eq 1 ]; then
+    echo ""
+    echo "==> CWE-362 RACE CONDITION: STILL PRESENT (fix failed)"
+    ((FAIL++))
+else
+    echo ""
+    echo "==> CWE-362 RACE CONDITION: FIXED (no races detected)"
+    ((PASS++))
+fi
+((TOTAL++))
+
+#############################################
+# CRITICAL ISSUE 2: NULL Dereference (CWE-476)
+#############################################
+echo ""
+echo "########################################"
+echo "# CRITICAL 2: NULL Dereference (CWE-476)"
+echo "########################################"
+echo ""
+echo "When strtok() returns NULL for malformed JWT,"
+echo "strlen() is called on NULL causing SIGSEGV."
+echo "Location: main.c:232-237"
+echo ""
+
+NULL_CRASH_1=0
+NULL_CRASH_2=0
+NULL_CRASH_3=0
+NULL_CRASH_4=0
+
+# Test 2a: No dots at all
+echo "--- Test 2a: JWT with no dots ---"
+echo "Input: 'nodots'"
+echo ""
+set +e
+./jwtcrack nodots abc 2 sha256 2>&1
+EXIT_2A=$?
+set -e
+if [ $EXIT_2A -eq 139 ] || [ $EXIT_2A -eq 134 ] || [ $EXIT_2A -eq 136 ] || [ $EXIT_2A -eq 11 ]; then
+    echo ""
+    echo ">>> VULNERABILITY CONFIRMED: Program crashed (exit code $EXIT_2A)"
+    echo ">>> Exit code 139=SIGSEGV, 134=SIGABRT, 136=SIGFPE, 11=SIGSEGV(raw)"
+    NULL_CRASH_1=1
+else
+    echo ""
+    echo "Exit code: $EXIT_2A (no crash)"
+    NULL_CRASH_1=0
+fi
+
+# Test 2b: Only one dot (missing signature)
+echo ""
+echo "--- Test 2b: JWT with only one dot ---"
+echo "Input: 'header.payload'"
+echo ""
+set +e
+./jwtcrack header.payload abc 2 sha256 2>&1
+EXIT_2B=$?
+set -e
+if [ $EXIT_2B -eq 139 ] || [ $EXIT_2B -eq 134 ] || [ $EXIT_2B -eq 136 ] || [ $EXIT_2B -eq 11 ]; then
+    echo ""
+    echo ">>> VULNERABILITY CONFIRMED: Program crashed (exit code $EXIT_2B)"
+    NULL_CRASH_2=1
+else
+    echo ""
+    echo "Exit code: $EXIT_2B (no crash)"
+    NULL_CRASH_2=0
+fi
+
+# Test 2c: Empty string
+echo ""
+echo "--- Test 2c: Empty JWT string ---"
+echo "Input: ''"
+echo ""
+set +e
+./jwtcrack "" abc 2 sha256 2>&1
+EXIT_2C=$?
+set -e
+if [ $EXIT_2C -eq 139 ] || [ $EXIT_2C -eq 134 ] || [ $EXIT_2C -eq 136 ] || [ $EXIT_2C -eq 11 ]; then
+    echo ""
+    echo ">>> VULNERABILITY CONFIRMED: Program crashed (exit code $EXIT_2C)"
+    NULL_CRASH_3=1
+else
+    echo ""
+    echo "Exit code: $EXIT_2C (no crash)"
+    NULL_CRASH_3=0
+fi
+
+# Test 2d: Two dots but empty parts
+echo ""
+echo "--- Test 2d: JWT with two dots but empty parts ---"
+echo "Input: '..'"
+echo ""
+set +e
+./jwtcrack ".." abc 2 sha256 2>&1
+EXIT_2D=$?
+set -e
+if [ $EXIT_2D -eq 139 ] || [ $EXIT_2D -eq 134 ] || [ $EXIT_2D -eq 136 ] || [ $EXIT_2D -eq 11 ]; then
+    echo ""
+    echo ">>> VULNERABILITY CONFIRMED: Program crashed (exit code $EXIT_2D)"
+    NULL_CRASH_4=1
+else
+    echo ""
+    echo "Exit code: $EXIT_2D (no crash)"
+    NULL_CRASH_4=0
+fi
+
+if [ $NULL_CRASH_1 -eq 1 ] || [ $NULL_CRASH_2 -eq 1 ] || [ $NULL_CRASH_3 -eq 1 ] || [ $NULL_CRASH_4 -eq 1 ]; then
+    echo ""
+    echo "==> CWE-476 NULL DEREFERENCE: STILL PRESENT (fix failed)"
+    ((FAIL++))
+else
+    echo ""
+    echo "==> CWE-476 NULL DEREFERENCE: FIXED (proper error handling)"
+    ((PASS++))
+fi
+((TOTAL++))
+
+#############################################
+# CRITICAL ISSUE 3: Base64/Base64URL Mismatch
+#############################################
+echo ""
+echo "########################################"
+echo "# CRITICAL 3: Base64/Base64URL Mismatch"
+echo "########################################"
+echo ""
+echo "JWT uses Base64URL (-_ for index 62,63) but"
+echo "decoder rejects + (standard Base64 index 62)."
+echo "Location: base64.c:95"
+echo ""
+
+BASE64URL_WORKS=0
+
+echo "--- Test 3a: JWT with Base64URL signature (should work) ---"
+echo "Testing Base64 decoding of signature with '-' character..."
+echo ""
+
+# Test with the normal JWT first (should work)
+echo "Normal JWT (Base64URL signature with '-'):"
+set +e
+RESULT=$(./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234567 5 sha256 2>&1)
+set -e
+echo "$RESULT"
+if echo "$RESULT" | grep -q 'Secret is "Sn1f"'; then
+    echo "Base64URL (-) decoding: WORKS"
+    BASE64URL_WORKS=1
+else
+    echo "Base64URL (-) decoding: FAILED"
+    BASE64URL_WORKS=0
+fi
+
+echo ""
+echo "--- Test 3b: Checking pr2six table values ---"
+echo ""
+echo "Per RFC 4648 Section 5 (Base64URL):"
+echo "  Index 62 should accept BOTH '+' (Base64) AND '-' (Base64URL)"
+echo "  Index 63 should accept BOTH '/' (Base64) AND '_' (Base64URL)"
+echo ""
+
+if [ $BASE64URL_WORKS -eq 1 ]; then
+    echo "==> BASE64/BASE64URL: WORKING CORRECTLY"
+    echo "    (Both '+' and '-' are accepted for index 62)"
+    ((PASS++))
+else
+    echo "==> BASE64/BASE64URL: FAILED"
+    ((FAIL++))
+fi
+((TOTAL++))
+
+#############################################
+# SUMMARY
+#############################################
+echo ""
+echo "========================================"
+echo "SECURITY TEST SUMMARY"
+echo "========================================"
+echo ""
+echo "Total tests: $TOTAL"
+echo "Fixes verified: $PASS"
+echo "Fixes failed: $FAIL"
+echo ""
+echo "Security Fixes Status:"
+if [ $RACE_DETECTED -eq 1 ]; then
+    echo "  1. CWE-362 Race Condition:    FAILED (still vulnerable)"
+else
+    echo "  1. CWE-362 Race Condition:    FIXED"
+fi
+if [ $NULL_CRASH_1 -eq 1 ] || [ $NULL_CRASH_2 -eq 1 ] || [ $NULL_CRASH_3 -eq 1 ] || [ $NULL_CRASH_4 -eq 1 ]; then
+    echo "  2. CWE-476 NULL Dereference:  FAILED (still crashes)"
+else
+    echo "  2. CWE-476 NULL Dereference:  FIXED"
+fi
+if [ $BASE64URL_WORKS -eq 1 ]; then
+    echo "  3. Base64/Base64URL Support:  WORKING"
+else
+    echo "  3. Base64/Base64URL Support:  FAILED"
+fi
+echo ""
+
+#############################################
+# MEDIUM ISSUE 4: Integer Overflow atoi (CWE-190)
+#############################################
+echo ""
+echo "########################################"
+echo "# MEDIUM 4: Integer Overflow (CWE-190)"
+echo "########################################"
+echo ""
+echo "atoi() has undefined behavior for out-of-range values."
+echo "Fix: Use strtol() with proper validation and range check (1-1000)."
+echo ""
+
+INT_VALIDATION_WORKS=1
+
+# Test 4a: Very large max_len value - should be rejected
+echo "--- Test 4a: Very large max_len (2147483648 = INT_MAX+1) ---"
+echo "Input: max_len=2147483648"
+echo ""
+set +e
+OUTPUT_4A=$(timeout 5 ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE abc 2147483648 sha256 2>&1)
+EXIT_4A=$?
+set -e
+echo "$OUTPUT_4A"
+echo ""
+echo "Exit code: $EXIT_4A"
+if echo "$OUTPUT_4A" | grep -q "Invalid max_len\|defaults to"; then
+    echo "PASS: Large value properly rejected with error message"
+else
+    echo "FAIL: Large value not properly validated"
+    INT_VALIDATION_WORKS=0
+fi
+
+# Test 4b: Negative value - should be rejected
+echo ""
+echo "--- Test 4b: Negative max_len ---"
+echo "Input: max_len=-1"
+echo ""
+set +e
+OUTPUT_4B=$(./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE abc -1 sha256 2>&1)
+EXIT_4B=$?
+set -e
+echo "$OUTPUT_4B"
+echo ""
+echo "Exit code: $EXIT_4B"
+if echo "$OUTPUT_4B" | grep -q "Invalid max_len\|defaults to"; then
+    echo "PASS: Negative value properly rejected"
+else
+    echo "FAIL: Negative value not properly validated"
+    INT_VALIDATION_WORKS=0
+fi
+
+# Test 4c: Non-numeric value - should be rejected
+echo ""
+echo "--- Test 4c: Non-numeric max_len ---"
+echo "Input: max_len=abc"
+echo ""
+set +e
+OUTPUT_4C=$(./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE abc abc sha256 2>&1)
+EXIT_4C=$?
+set -e
+echo "$OUTPUT_4C"
+echo ""
+echo "Exit code: $EXIT_4C"
+if echo "$OUTPUT_4C" | grep -q "Invalid max_len\|defaults to"; then
+    echo "PASS: Non-numeric value properly rejected"
+else
+    echo "FAIL: Non-numeric value not properly validated"
+    INT_VALIDATION_WORKS=0
+fi
+
+# Test 4d: Value over 1000 - should be rejected (new upper bound)
+echo ""
+echo "--- Test 4d: max_len over 1000 ---"
+echo "Input: max_len=1001"
+echo ""
+set +e
+OUTPUT_4D=$(./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE abc 1001 sha256 2>&1)
+EXIT_4D=$?
+set -e
+echo "$OUTPUT_4D"
+echo ""
+echo "Exit code: $EXIT_4D"
+if echo "$OUTPUT_4D" | grep -q "Invalid max_len\|defaults to"; then
+    echo "PASS: Value over 1000 properly rejected"
+else
+    echo "FAIL: Value over 1000 not properly validated"
+    INT_VALIDATION_WORKS=0
+fi
+
+if [ $INT_VALIDATION_WORKS -eq 1 ]; then
+    echo ""
+    echo "==> CWE-190 INTEGER OVERFLOW: FIXED"
+    echo "    strtol() with proper validation now used"
+    ((PASS++))
+else
+    echo ""
+    echo "==> CWE-190 INTEGER OVERFLOW: ISSUE PRESENT"
+    ((FAIL++))
+fi
+((TOTAL++))
+
+#############################################
+# MEDIUM ISSUE 5: VLA Stack Overflow (CWE-121)
+#############################################
+echo ""
+echo "########################################"
+echo "# MEDIUM 5: VLA Stack Overflow (CWE-121)"
+echo "########################################"
+echo ""
+echo "Variable-length array on stack can overflow"
+echo "with large alphabet sizes."
+echo "Fix: Heap allocate thread data array instead of VLA."
+echo ""
+
+VLA_WORKS=1
+
+# Test 5a: Very large alphabet (10000 characters)
+echo "--- Test 5a: Large alphabet (10000 chars) ---"
+echo "Previously would create VLA of 10000 pointers on stack"
+echo ""
+
+# Generate a large alphabet
+LARGE_ALPHABET=$(printf 'a%.0s' $(seq 1 10000))
+echo "Alphabet length: ${#LARGE_ALPHABET}"
+echo ""
+
+set +e
+timeout 5 ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE "$LARGE_ALPHABET" 1 sha256 2>&1
+EXIT_5A=$?
+set -e
+echo ""
+echo "Exit code: $EXIT_5A"
+if [ $EXIT_5A -eq 139 ] || [ $EXIT_5A -eq 134 ] || [ $EXIT_5A -eq 137 ] || [ $EXIT_5A -eq 136 ]; then
+    echo "FAIL: Stack overflow with large alphabet"
+    VLA_WORKS=0
+else
+    echo "PASS: Large alphabet handled without stack overflow"
+fi
+
+# Test 5b: Even larger alphabet (100000 characters)
+echo ""
+echo "--- Test 5b: Very large alphabet (100000 chars) ---"
+echo ""
+
+VERY_LARGE_ALPHABET=$(printf 'a%.0s' $(seq 1 100000))
+echo "Alphabet length: ${#VERY_LARGE_ALPHABET}"
+echo ""
+
+set +e
+timeout 5 ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE "$VERY_LARGE_ALPHABET" 1 sha256 2>&1
+EXIT_5B=$?
+set -e
+echo ""
+echo "Exit code: $EXIT_5B"
+if [ $EXIT_5B -eq 139 ] || [ $EXIT_5B -eq 134 ] || [ $EXIT_5B -eq 137 ] || [ $EXIT_5B -eq 136 ]; then
+    echo "FAIL: Stack overflow with very large alphabet"
+    VLA_WORKS=0
+else
+    echo "PASS: Very large alphabet handled without stack overflow"
+fi
+
+# Test 5c: Verify heap allocation in code
+echo ""
+echo "--- Test 5c: Verify heap allocation in code ---"
+if grep -q "struct s_thread_data \*\*pointers_data = malloc" /opt/src/main.c; then
+    echo "PASS: Thread data array is heap allocated"
+else
+    echo "FAIL: Thread data array not heap allocated"
+    VLA_WORKS=0
+fi
+
+if [ $VLA_WORKS -eq 1 ]; then
+    echo ""
+    echo "==> CWE-121 VLA STACK OVERFLOW: FIXED"
+    echo "    Thread data array now heap allocated"
+    ((PASS++))
+else
+    echo ""
+    echo "==> CWE-121 VLA STACK OVERFLOW: ISSUE PRESENT"
+    ((FAIL++))
+fi
+((TOTAL++))
+
+#############################################
+# MEDIUM ISSUE 6: Unchecked malloc (CWE-252)
+#############################################
+echo ""
+echo "########################################"
+echo "# MEDIUM 6: Unchecked malloc (CWE-252)"
+echo "########################################"
+echo ""
+echo "malloc() return values not checked for NULL."
+echo "Fix: Add NULL checks after all malloc calls."
+echo ""
+
+MALLOC_CHECKED=1
+
+echo "--- Test 6a: Verify malloc NULL checks in code ---"
+echo ""
+
+# Count malloc calls that have NULL checks nearby
+TOTAL_MALLOCS=$(grep -c "malloc(" /opt/src/main.c || echo 0)
+CHECKED_MALLOCS=$(grep -B1 -A1 "malloc(" /opt/src/main.c | grep -c "== NULL\|!= NULL" || echo 0)
+
+echo "Total malloc calls: $TOTAL_MALLOCS"
+echo "Malloc calls with NULL checks: $CHECKED_MALLOCS"
+echo ""
+
+# Check specific malloc patterns
+echo "--- Test 6b: Verify specific malloc NULL checks ---"
+echo ""
+
+# Check init_thread_data returns error on malloc failure
+if grep -q "if (data->g_result == NULL)" /opt/src/main.c && grep -q "if (data->g_buffer == NULL)" /opt/src/main.c; then
+    echo "PASS: init_thread_data checks malloc returns"
+else
+    echo "FAIL: init_thread_data missing malloc checks"
+    MALLOC_CHECKED=0
+fi
+
+# Check g_to_encrypt malloc
+if grep -q "if (g_to_encrypt == NULL)" /opt/src/main.c; then
+    echo "PASS: g_to_encrypt malloc is checked"
+else
+    echo "FAIL: g_to_encrypt malloc not checked"
+    MALLOC_CHECKED=0
+fi
+
+# Check g_signature malloc
+if grep -q "if (g_signature == NULL)" /opt/src/main.c; then
+    echo "PASS: g_signature malloc is checked"
+else
+    echo "FAIL: g_signature malloc not checked"
+    MALLOC_CHECKED=0
+fi
+
+# Check pointers_data malloc
+if grep -q "if (pointers_data == NULL)" /opt/src/main.c; then
+    echo "PASS: pointers_data malloc is checked"
+else
+    echo "FAIL: pointers_data malloc not checked"
+    MALLOC_CHECKED=0
+fi
+
+# Check tid malloc
+if grep -q "if (tid == NULL)" /opt/src/main.c; then
+    echo "PASS: tid malloc is checked"
+else
+    echo "FAIL: tid malloc not checked"
+    MALLOC_CHECKED=0
+fi
+
+echo ""
+if [ $MALLOC_CHECKED -eq 1 ]; then
+    echo "==> CWE-252 UNCHECKED MALLOC: FIXED"
+    echo "    All malloc returns are now validated"
+    ((PASS++))
+else
+    echo "==> CWE-252 UNCHECKED MALLOC: ISSUE PRESENT"
+    ((FAIL++))
+fi
+((TOTAL++))
+
+#############################################
+# MEDIUM ISSUE 7: Timing Side-Channel (CWE-208)
+#############################################
+echo ""
+echo "########################################"
+echo "# HIGH 7: Timing Side-Channel (CWE-208)"
+echo "########################################"
+echo ""
+echo "memcmp() is not constant-time and may leak"
+echo "information via timing differences."
+echo "Fix: Use constant-time comparison function."
+echo ""
+
+TIMING_FIXED=1
+
+echo "--- Test 7a: Verify constant-time compare function exists ---"
+if grep -q "constant_time_compare" /opt/src/main.c; then
+    echo "PASS: constant_time_compare function found"
+else
+    echo "FAIL: constant_time_compare function not found"
+    TIMING_FIXED=0
+fi
+
+echo ""
+echo "--- Test 7b: Verify memcmp is NOT used for signature comparison ---"
+if grep -q "memcmp.*g_signature\|memcmp.*g_result" /opt/src/main.c; then
+    echo "FAIL: memcmp still used for signature comparison"
+    TIMING_FIXED=0
+else
+    echo "PASS: memcmp not used for signature comparison"
+fi
+
+echo ""
+echo "--- Test 7c: Verify constant_time_compare is used ---"
+if grep -q "constant_time_compare(data->g_result, g_signature" /opt/src/main.c; then
+    echo "PASS: constant_time_compare used for signature comparison"
+else
+    echo "FAIL: constant_time_compare not used for signature comparison"
+    TIMING_FIXED=0
+fi
+
+echo ""
+if [ $TIMING_FIXED -eq 1 ]; then
+    echo "==> CWE-208 TIMING ATTACK: FIXED"
+    echo "    constant_time_compare() now used for signature comparison"
+    ((PASS++))
+else
+    echo "==> CWE-208 TIMING ATTACK: ISSUE PRESENT"
+    ((FAIL++))
+fi
+((TOTAL++))
+
+#############################################
+# SUMMARY
+#############################################
+echo ""
+echo "========================================"
+echo "SECURITY TEST SUMMARY"
+echo "========================================"
+echo ""
+echo "Total test categories: $TOTAL"
+echo "Fixes verified: $PASS"
+echo "Issues remaining: $FAIL"
+echo ""
+echo "Critical Security Fixes:"
+if [ $RACE_DETECTED -eq 1 ]; then
+    echo "  1. CWE-362 Race Condition:    FAILED (still vulnerable)"
+else
+    echo "  1. CWE-362 Race Condition:    FIXED"
+fi
+if [ $NULL_CRASH_1 -eq 1 ] || [ $NULL_CRASH_2 -eq 1 ] || [ $NULL_CRASH_3 -eq 1 ] || [ $NULL_CRASH_4 -eq 1 ]; then
+    echo "  2. CWE-476 NULL Dereference:  FAILED (still crashes)"
+else
+    echo "  2. CWE-476 NULL Dereference:  FIXED"
+fi
+if [ $BASE64URL_WORKS -eq 1 ]; then
+    echo "  3. Base64/Base64URL Support:  WORKING"
+else
+    echo "  3. Base64/Base64URL Support:  FAILED"
+fi
+echo ""
+echo "Medium/High Priority Fixes:"
+if [ $INT_VALIDATION_WORKS -eq 1 ]; then
+    echo "  4. CWE-190 Integer Overflow:  FIXED"
+else
+    echo "  4. CWE-190 Integer Overflow:  FAILED"
+fi
+if [ $VLA_WORKS -eq 1 ]; then
+    echo "  5. CWE-121 VLA Stack Overflow: FIXED"
+else
+    echo "  5. CWE-121 VLA Stack Overflow: FAILED"
+fi
+if [ $MALLOC_CHECKED -eq 1 ]; then
+    echo "  6. CWE-252 Unchecked malloc:  FIXED"
+else
+    echo "  6. CWE-252 Unchecked malloc:  FAILED"
+fi
+if [ $TIMING_FIXED -eq 1 ]; then
+    echo "  7. CWE-208 Timing Attack:     FIXED"
+else
+    echo "  7. CWE-208 Timing Attack:     FAILED"
+fi
+echo ""
+
+# Also run standard functional tests
+echo "========================================"
+echo "STANDARD FUNCTIONAL TESTS"
+echo "========================================"
+echo ""
+
+echo "--- Functional Test: HS256 (secret: Sn1f) ---"
+RESULT=$(./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234567 5 sha256)
+echo "$RESULT"
+if echo "$RESULT" | grep -q 'Secret is "Sn1f"'; then
+    echo "PASSED"
+else
+    echo "FAILED"
+fi
+
+echo ""
+echo "--- Memory Test: Valgrind leak check ---"
+set +e
+valgrind --leak-check=full --error-exitcode=1 \
+    ./jwtcrack eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.cAOIAifu3fykvhkHpbuhbvtH807-Z2rI1FS3vX1XMjE ABCSNFabcsnf1234567 5 sha256
+VALGRIND_EXIT=$?
+set -e
+if [ $VALGRIND_EXIT -eq 0 ]; then
+    echo "PASSED - No memory leaks"
+else
+    echo "FAILED - Memory leaks detected"
+fi
+
+echo ""
+echo "========================================"
+echo "TEST SUITE COMPLETE"
+echo "========================================"


### PR DESCRIPTION
## Summary

Comprehensive security fixes addressing multiple CWE vulnerabilities and Docker hardening.

## Fixes

### Critical Security (CWE)
- **CWE-362 Race Condition**: Add C11 atomics for thread-safe `g_found_secret` access
- **CWE-476 NULL Dereference**: Add NULL checks after `strtok()` for malformed JWT input
- **CWE-190 Integer Overflow**: Replace `atoi()` with `strtol()` with validation (range 1-1000)
- **CWE-208 Timing Attack**: Replace `memcmp()` with constant-time comparison function
- **CWE-252 Unchecked Return**: Add NULL checks for all 7 `malloc()` calls
- **CWE-121 Stack Overflow**: Replace VLA with heap allocation for thread data array

### Base64 Fix
- **Base64URL Support**: Accept both `+` and `-` for index 62 per RFC 4648

### Docker Security
- **Non-root USER**: Add unprivileged user in Dockerfile and Dockerfile.test
- **OpenSSL CVEs**: Add `apk upgrade` to patch CVE-2025-9230, CVE-2025-9231, CVE-2025-9232
- **Remove redundant build**: Single `make` command (macOS paths removed)
- **Shell quoting**: Fix `$@` to `"$@"` in entrypoint.sh

### Testing & CI
- **Valgrind tests**: Add Dockerfile.test with memory leak and race detection
- **Security test suite**: Add test_security.sh verifying all fixes
- **Trivy scanning**: Add GitHub Actions workflow for container scanning
- **Documentation**: Add FIXES-PROPOSED.md and FIXES-PROPOSED-v2.md